### PR TITLE
Update Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -2,7 +2,7 @@ FROM ubuntu:18.04
 
 RUN apt-get update && \
     apt-get upgrade -y && \
-    apt-get install -y \
+    apt-get install -y --fix-missing  \
         wget \
         unzip \
         libgtk-3-0 \


### PR DESCRIPTION
Apt install software without verifying the hash value
做apt upgrade操作时，因 libglib2.0-0_2.56.3-0ubuntu0.18.04.1_amd64.deb 哈西值校验失败而无法构建docker容器